### PR TITLE
Renamed useLocalStorage into useStateLocalStorage

### DIFF
--- a/exercises/module2/2.3/src/components/ClickCounter/ClickCounter.jsx
+++ b/exercises/module2/2.3/src/components/ClickCounter/ClickCounter.jsx
@@ -1,13 +1,13 @@
 import { useState } from "react";
 import "./ClickCounter.css";
-import useLocalStorage from "hooks/useLocalStorage";
+import useStateLocalStorage from "hooks/useStateLocalStorage";
 
 const ClickCounter = ({
   title,
   on10ClickMessage = "Master !",
   onMouseOverMessage = "Click !",
 }) => {
-  const [count, setCount] = useLocalStorage("count", 0);
+  const [count, setCount] = useStateLocalStorage("count", 0);
   const [isHovered, setIsHovered] = useState(false);
 
   return (
@@ -18,7 +18,6 @@ const ClickCounter = ({
         onClick={() => {
           const newCount = count + 1;
           setCount(newCount);
-          localStorage.setItem("count", JSON.stringify(newCount));
         }}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}

--- a/exercises/module2/2.3/src/hooks/useStateLocalStorage.js
+++ b/exercises/module2/2.3/src/hooks/useStateLocalStorage.js
@@ -10,7 +10,7 @@ const fetchValue = (key, defaultValue) => {
   return serializedValue ? JSON.parse(serializedValue) : defaultValue;
 };
 
-const useLocalStorage = (key, initialValue) => {
+const useStateLocalStorage = (key, initialValue) => {
   const currentValue = fetchValue(key, initialValue);
   const [stateValue, stateSetter] = useState(currentValue);
 
@@ -22,4 +22,4 @@ const useLocalStorage = (key, initialValue) => {
   return [stateValue, persistentSetter];
 };
 
-export default useLocalStorage;
+export default useStateLocalStorage;


### PR DESCRIPTION
Le nom me semble plus proche de l'original `useState` et donc plus approprié.